### PR TITLE
refactor(tests): simplify ObjectMapper usage in tests

### DIFF
--- a/src/test/java/com/github/eddranca/datagenerator/DslDataGeneratorTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/DslDataGeneratorTest.java
@@ -87,10 +87,7 @@ class DslDataGeneratorTest {
 
         @Test
         void testSeedConsistencyWithCustomGenerators() throws IOException {
-            Generator customGenerator = (options) -> {
-                ObjectMapper mapper = new ObjectMapper();
-                return mapper.valueToTree("CUSTOM_FIXED_VALUE");
-            };
+            Generator customGenerator = (options) -> mapper.valueToTree("CUSTOM_FIXED_VALUE");
 
             JsonNode dslNode = mapper.readTree("""
                     {
@@ -150,7 +147,6 @@ class DslDataGeneratorTest {
 
         @Test
         void testSeedConsistencyWithFluentAPI() throws Exception {
-            ObjectMapper mapper = new ObjectMapper();
             JsonNode dslNode = mapper.readTree("""
                     {
                         "users": {
@@ -716,7 +712,6 @@ class DslDataGeneratorTest {
 
         @Test
         void testSpreadOperatorSqlGeneration() throws Exception {
-            ObjectMapper mapper = new ObjectMapper();
             JsonNode dslNode = mapper.readTree("""
                     {
                         "companies": {
@@ -1540,9 +1535,7 @@ class DslDataGeneratorTest {
             when(mockFaker.name()).thenReturn(mockName);
             when(mockFaker.random()).thenReturn(mockRandom);
 
-            // Create DSL JsonNode that only uses firstName and lastName (not fullName,
-            // title, prefix, suffix)
-            ObjectMapper mapper = new ObjectMapper();
+            // Create DSL JsonNode that only uses firstName and lastName (not fullName, title, prefix, suffix)
             JsonNode dslNode = mapper.readTree("""
                     {
                         "users": {
@@ -1594,9 +1587,7 @@ class DslDataGeneratorTest {
             Faker mockFaker = mock(Faker.class);
             when(mockFaker.address()).thenReturn(mockAddress);
 
-            // Create DSL JsonNode that only uses streetAddress and city (not state,
-            // zipCode, country)
-            ObjectMapper mapper = new ObjectMapper();
+            // Create DSL JsonNode that only uses streetAddress and city (not state, zipCode, country)
             JsonNode dslNode = mapper.readTree("""
                     {
                         "locations": {
@@ -1645,9 +1636,7 @@ class DslDataGeneratorTest {
             Faker mockFaker = mock(Faker.class);
             when(mockFaker.company()).thenReturn(mockCompany);
 
-            // Create DSL JsonNode that only uses company name (not industry, profession,
-            // buzzword)
-            ObjectMapper mapper = new ObjectMapper();
+            // Create DSL JsonNode that only uses company name (not industry, profession, buzzword)
             JsonNode dslNode = mapper.readTree("""
                     {
                         "businesses": {
@@ -1694,9 +1683,7 @@ class DslDataGeneratorTest {
             Faker mockFaker = mock(Faker.class);
             when(mockFaker.internet()).thenReturn(mockInternet);
 
-            // Create DSL JsonNode that only uses emailAddress (not domainName, url,
-            // password)
-            ObjectMapper mapper = new ObjectMapper();
+            // Create DSL JsonNode that only uses emailAddress (not domainName, url, password)
             JsonNode dslNode = mapper.readTree("""
                     {
                         "contacts": {

--- a/src/test/java/com/github/eddranca/datagenerator/FilteringConfigurationTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/FilteringConfigurationTest.java
@@ -12,10 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FilteringConfigurationTest {
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void testDefaultFilteringBehaviorReturnsNull() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "items": {
@@ -50,7 +50,6 @@ class FilteringConfigurationTest {
 
     @Test
     void testThrowExceptionFilteringBehaviorForGenerators() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "items": {
@@ -78,7 +77,6 @@ class FilteringConfigurationTest {
 
     @Test
     void testThrowExceptionFilteringBehaviorForReferences() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "reference_data": {
@@ -111,7 +109,6 @@ class FilteringConfigurationTest {
 
     @Test
     void testCustomMaxFilteringRetries() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "items": {
@@ -174,7 +171,6 @@ class FilteringConfigurationTest {
 
     @Test
     void testSuccessfulFilteringWithCustomRetries() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "items": {

--- a/src/test/java/com/github/eddranca/datagenerator/GeneratorFilteringTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/GeneratorFilteringTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 
 class GeneratorFilteringTest {
-    ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void testBasicGeneratorFiltering() throws IOException {

--- a/src/test/java/com/github/eddranca/datagenerator/MultiStepCollectionTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/MultiStepCollectionTest.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MultiStepCollectionTest {
-    ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void testMultiStepCollectionGeneration() throws IOException {

--- a/src/test/java/com/github/eddranca/datagenerator/ReferenceSpreadTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/ReferenceSpreadTest.java
@@ -13,10 +13,10 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ReferenceSpreadTest {
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void testBasicReferenceSpread() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree(
                 """
                         {
@@ -69,7 +69,6 @@ class ReferenceSpreadTest {
 
     @Test
     void testReferenceSpreadWithFieldRenaming() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {
@@ -120,7 +119,6 @@ class ReferenceSpreadTest {
 
     @Test
     void testReferenceSpreadWithoutFieldsArray() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {
@@ -167,7 +165,6 @@ class ReferenceSpreadTest {
 
     @Test
     void testReferenceSpreadWithSequential() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {

--- a/src/test/java/com/github/eddranca/datagenerator/SequentialReferenceTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/SequentialReferenceTest.java
@@ -69,7 +69,6 @@ class SequentialReferenceTest {
 
     @Test
     void testSequentialReferenceWithFiltering() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {
@@ -137,7 +136,6 @@ class SequentialReferenceTest {
 
     @Test
     void testRandomVsSequentialReference() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {
@@ -207,7 +205,6 @@ class SequentialReferenceTest {
 
     @Test
     void testSequentialReferenceWithTaggedCollections() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "staff_admins": {

--- a/src/test/java/com/github/eddranca/datagenerator/StaticValueTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/StaticValueTest.java
@@ -14,10 +14,10 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class StaticValueTest {
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void testBasicStaticValues() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "products": {
@@ -69,7 +69,6 @@ class StaticValueTest {
 
     @Test
     void testComplexStaticValues() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "orders": {
@@ -136,7 +135,6 @@ class StaticValueTest {
 
     @Test
     void testMixedStaticAndDynamicFields() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {

--- a/src/test/java/com/github/eddranca/datagenerator/StreamingGenerationTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/StreamingGenerationTest.java
@@ -6,15 +6,14 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class StreamingGenerationTest {
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void testStreamingWithReferences() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "categories": {
@@ -57,7 +56,6 @@ class StreamingGenerationTest {
 
     @Test
     void testStreamingMultipleCollections() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {
@@ -103,7 +101,6 @@ class StreamingGenerationTest {
 
     @Test
     void testStreamingWithMultiStepCollections() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "admin_users": {
@@ -157,7 +154,6 @@ class StreamingGenerationTest {
     @Test
     void testStreamingMemoryEfficiency() throws IOException {
         // This test demonstrates that streaming doesn't load all data into memory
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "large_dataset": {

--- a/src/test/java/com/github/eddranca/datagenerator/TagValidationTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/TagValidationTest.java
@@ -11,10 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TagValidationTest {
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void testValidTagSharing() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {
@@ -48,7 +48,6 @@ class TagValidationTest {
 
     @Test
     void testInvalidTagSharing() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {
@@ -82,7 +81,6 @@ class TagValidationTest {
 
     @Test
     void testValidTagSharingWithCustomNames() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "user_data": {
@@ -117,7 +115,6 @@ class TagValidationTest {
 
     @Test
     void testInvalidTagSharingWithCustomNames() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "user_data": {
@@ -153,7 +150,6 @@ class TagValidationTest {
 
     @Test
     void testMultipleTagsValidation() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {
@@ -187,7 +183,6 @@ class TagValidationTest {
 
     @Test
     void testSingleCollectionMultipleTags() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode dslNode = mapper.readTree("""
                 {
                     "users": {

--- a/src/test/java/com/github/eddranca/datagenerator/generator/GeneratorRegistryTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/generator/GeneratorRegistryTest.java
@@ -81,10 +81,7 @@ class GeneratorRegistryTest {
 
     @Test
     void testRegisterCustomGenerator() {
-        Generator customGenerator = (options) -> {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.valueToTree("CUSTOM_VALUE");
-        };
+        Generator customGenerator = (options) -> mapper.valueToTree("CUSTOM_VALUE");
 
         registry.register("custom", customGenerator);
 
@@ -98,10 +95,7 @@ class GeneratorRegistryTest {
 
     @Test
     void testOverrideExistingGenerator() {
-        Generator customUuidGenerator = (options) -> {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.valueToTree("CUSTOM_UUID");
-        };
+        Generator customUuidGenerator = (options) -> mapper.valueToTree("CUSTOM_UUID");
 
         // Override existing uuid generator
         registry.register("uuid", customUuidGenerator);

--- a/src/test/java/com/github/eddranca/datagenerator/generator/defaults/UuidGeneratorTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/generator/defaults/UuidGeneratorTest.java
@@ -48,7 +48,6 @@ class UuidGeneratorTest {
     @Test
     void testGenerateWithDifferentOptions() throws Exception {
         // UUID generator should ignore options and always generate valid UUIDs
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode customOptions = mapper.readTree("{\"someOption\": \"someValue\"}");
 
         JsonNode result = generator.generate(customOptions);

--- a/src/test/java/com/github/eddranca/datagenerator/integration/ComplexDslIntegrationTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/integration/ComplexDslIntegrationTest.java
@@ -426,7 +426,6 @@ class ComplexDslIntegrationTest {
 
     @Test
     void testCsvGeneratorUsersIntegration() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         String csvPath = "src/test/resources/test-users.csv";
 
         JsonNode dslNode = mapper.readTree(String.format("""
@@ -471,7 +470,6 @@ class ComplexDslIntegrationTest {
 
     @Test
     void testCsvGeneratorPickFieldIntegration() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         String csvPath = "src/test/resources/test-users.csv";
 
         // TODO: This should work with just "item": { "gen": "csv", ... } but currently requires the nested 'user' object

--- a/src/test/java/com/github/eddranca/datagenerator/integration/GeneratorIntegrationTest.java
+++ b/src/test/java/com/github/eddranca/datagenerator/integration/GeneratorIntegrationTest.java
@@ -13,29 +13,29 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests the interaction between boolean, lorem, phone, and other generators.
  */
 class GeneratorIntegrationTest {
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void testMultipleGeneratorsInDsl() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
 
-    String dsl = """
-        {
-          "testData": {
-            "count": 3,
-            "item": {
-              "id": { "gen": "uuid" },
-              "isActive": { "gen": "boolean" },
-              "probability": { "gen": "boolean", "probability": 0.8 },
-              "description": { "gen": "lorem", "sentences": 2 },
-              "keywords": { "gen": "lorem", "words": 5 },
-              "content": { "gen": "lorem", "paragraphs": 1 },
-              "phone": { "gen": "phone" },
-              "cellPhone": { "gen": "phone", "format": "cell" },
-              "extension": { "gen": "phone", "format": "extension" }
+        String dsl = """
+            {
+              "testData": {
+                "count": 3,
+                "item": {
+                  "id": { "gen": "uuid" },
+                  "isActive": { "gen": "boolean" },
+                  "probability": { "gen": "boolean", "probability": 0.8 },
+                  "description": { "gen": "lorem", "sentences": 2 },
+                  "keywords": { "gen": "lorem", "words": 5 },
+                  "content": { "gen": "lorem", "paragraphs": 1 },
+                  "phone": { "gen": "phone" },
+                  "cellPhone": { "gen": "phone", "format": "cell" },
+                  "extension": { "gen": "phone", "format": "extension" }
+                }
+              }
             }
-          }
-        }
-        """;
+            """;
 
         JsonNode dslNode = mapper.readTree(dsl);
 
@@ -96,20 +96,18 @@ class GeneratorIntegrationTest {
 
     @Test
     void testBooleanProbabilityDistribution() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
-    String dsl = """
-        {
-          "booleanTest": {
-            "count": 100,
-            "item": {
-              "alwaysTrue": { "gen": "boolean", "probability": 1.0 },
-              "alwaysFalse": { "gen": "boolean", "probability": 0.0 },
-              "mostlyTrue": { "gen": "boolean", "probability": 0.9 }
+        String dsl = """
+            {
+              "booleanTest": {
+                "count": 100,
+                "item": {
+                  "alwaysTrue": { "gen": "boolean", "probability": 1.0 },
+                  "alwaysFalse": { "gen": "boolean", "probability": 0.0 },
+                  "mostlyTrue": { "gen": "boolean", "probability": 0.9 }
+                }
+              }
             }
-          }
-        }
-        """;
+            """;
 
         JsonNode dslNode = mapper.readTree(dsl);
 
@@ -144,22 +142,20 @@ class GeneratorIntegrationTest {
 
     @Test
     void testLoremGeneratorVariations() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
-    // Test simple lorem generation (this works)
-    String simpleDsl = """
-        {
-          "loremTest": {
-            "count": 2,
-            "item": {
-              "description": { "gen": "lorem", "sentences": 1 },
-              "keywords": { "gen": "lorem", "words": 3 },
-              "content": { "gen": "lorem", "paragraphs": 1 },
-              "id": { "gen": "uuid" }
+        // Test simple lorem generation (this works)
+        String simpleDsl = """
+            {
+              "loremTest": {
+                "count": 2,
+                "item": {
+                  "description": { "gen": "lorem", "sentences": 1 },
+                  "keywords": { "gen": "lorem", "words": 3 },
+                  "content": { "gen": "lorem", "paragraphs": 1 },
+                  "id": { "gen": "uuid" }
+                }
+              }
             }
-          }
-        }
-        """;
+            """;
 
         JsonNode dslNode = mapper.readTree(simpleDsl);
 
@@ -193,23 +189,21 @@ class GeneratorIntegrationTest {
 
     @Test
     void testPhoneGeneratorFormats() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
-    String dsl = """
-        {
-          "contacts": {
-            "count": 5,
-            "item": {
-              "id": { "gen": "uuid" },
-              "name": { "gen": "name.fullName" },
-              "mainPhone": { "gen": "phone" },
-              "cellPhone": { "gen": "phone", "format": "cell" },
-              "workExtension": { "gen": "phone", "format": "extension" },
-              "isActive": { "gen": "boolean", "probability": 0.8 }
+        String dsl = """
+            {
+              "contacts": {
+                "count": 5,
+                "item": {
+                  "id": { "gen": "uuid" },
+                  "name": { "gen": "name.fullName" },
+                  "mainPhone": { "gen": "phone" },
+                  "cellPhone": { "gen": "phone", "format": "cell" },
+                  "workExtension": { "gen": "phone", "format": "extension" },
+                  "isActive": { "gen": "boolean", "probability": 0.8 }
+                }
+              }
             }
-          }
-        }
-        """;
+            """;
 
         JsonNode dslNode = mapper.readTree(dsl);
 


### PR DESCRIPTION
# Pull Request

## Description
Reuse `ObjectMapper` in tests instead of redefining it in every test method.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test improvements
- [x] Refactoring

## Testing
- [x] Tests pass locally
- [ ] New tests added for new functionality
- [ ] Existing tests updated if needed

## Documentation
- [ ] README updated (if needed)
- [ ] JavaDoc added/updated
- [ ] Examples added/updated

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Code Review Notes
Any specific areas you'd like reviewers to focus on?
